### PR TITLE
fix: 파티 헤더 이미지 편집시 편집기에 이미지 파일 외의 것이 들어가는 버그 수정

### DIFF
--- a/src/main/resources/static/js/page/main/party-create.js
+++ b/src/main/resources/static/js/page/main/party-create.js
@@ -42,11 +42,22 @@ $(function() {
 	$input.on('change', function (e) {
 		var files = e.target.files;
 		let size = input.files[0].size / 1024 / 1024;
+		let reg = /(.*?)\.(jpg|png)$/;
+		
+		// 확장자 검증
+	  	if(!files[0].name.match(reg)) {
+			alert("JPG, PNG 확장자 파일만 업로드 가능합니다.");
+			$input.value = ""
+			return;
+		}
+		
+		// 파일 크기 검증
         if(size > 30) {
                alert("이미지 파일 크기가 너무 큽니다. 30MB 이하의 파일을 업로드 해주세요.");
                $input.value = ""
                return;
 		}
+		
 		var done = function (url) {
         
 		$input.val("");

--- a/src/main/resources/static/js/page/party/modify.js
+++ b/src/main/resources/static/js/page/party/modify.js
@@ -34,6 +34,14 @@ $(function() {
 	$input.on("change", function (e) {
 		var files = e.target.files;
 		let size = input.files[0].size / 1024 / 1024;
+		let reg = /(.*?)\.(jpg|png)$/;
+		
+		// 확장자 검증
+	  	if(!files[0].name.match(reg)) {
+			alert("JPG, PNG 확장자 파일만 업로드 가능합니다.");
+			$input.value = ""
+			return;
+		}
         if(size > 30) {
                alert("이미지 파일 크기가 너무 큽니다. 30MB 이하의 파일을 업로드 해주세요.");
                $input.value = ""


### PR DESCRIPTION
<h1>구현사항</h1>

* 파티 생성, 혹은 수정시 헤더 편집기에 jpg, png 확장자가 아닌 파일의 업로드를 제한하는 함수 추가