### PR TITLE
131 feat allDay 자료형 변경, 일정 수정 구현, 조회 및 생성 변경

### DIFF
--- a/src/main/java/com/letsparty/mapper/EventMapper.java
+++ b/src/main/java/com/letsparty/mapper/EventMapper.java
@@ -14,21 +14,21 @@ public interface EventMapper {
 	void insertEvent(Event event);
 	
 	// 등록된 일정 수정하기
-	void updateEvent(int eventNo);
+	void updateEvent(int id);
 	
 	// 등록한 일정 상세정보 조회하기
-	Event getEventDetailByNo(int EventNo);
+	Event getEventDetailByNo(int id);
 	
 	// 일정번호로 일정 가져오기
-	Event getEventByNo(int EnvetNo);
+	Event getEventByNo(int id);
 	
 	// 일정목록 가져오기
-	List<Event> getEvents(LocalDateTime startDate, LocalDateTime endDate);
+	List<Event> getEvents(int partyNo, LocalDateTime startDate, LocalDateTime endDate);
 	
 	// 등록한 일정 삭제하기
-	void deleteEvent(int eventNo);
+	void deleteEvent(int id);
 	
-	void updateEvent(Event existingEvent);
+	void updateEvent(Event event);
 	
 	// 파티번호로 5개 일정 가져오기
 	List<Event> getEventsByPartyNo(int partyNo);

--- a/src/main/java/com/letsparty/service/EventService.java
+++ b/src/main/java/com/letsparty/service/EventService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import com.letsparty.mapper.EventMapper;
 import com.letsparty.vo.Event;
+import com.letsparty.vo.Party;
 import com.letsparty.vo.User;
 import com.letsparty.web.form.RegisterEventForm;
 
@@ -23,9 +24,15 @@ public class EventService {
 	private final EventMapper eventMapper;
 	
 	// 일정 정보 등록하기
-	public Event insertEvent(User user, RegisterEventForm registerEventForm) {
+	public Event insertEvent(RegisterEventForm registerEventForm, String userId) {
+		// TODO 파티권한 확인
 		Event event = new Event();
 		BeanUtils.copyProperties(registerEventForm, event);
+		Party party = new Party();
+		party.setNo(registerEventForm.getPartyNo());
+		event.setParty(party);
+		User user = new User();
+		user.setId(userId);
 		event.setUser(user);
 		
 		eventMapper.insertEvent(event);
@@ -33,31 +40,34 @@ public class EventService {
 		return event;
 	}    
 	
-	public void updateEvent(User user, RegisterEventForm updateEventForm, int eventNo) {
-		Event existingEvent = eventMapper.getEventByNo(eventNo);
-		
+	public boolean updateEvent(int id, RegisterEventForm updateEventForm, String userId) {
+		// TODO 파티권한 확인
+		Event existingEvent = eventMapper.getEventByNo(id);
 		if (existingEvent != null) {
 			// 업데이트 내용을 updateEventForm에서 가져와 existingEvent 적용
 			existingEvent.setTitle(updateEventForm.getTitle());
 			existingEvent.setDescription(updateEventForm.getDescription());
+			existingEvent.setAllDay(updateEventForm.isAllDay());
 			existingEvent.setStart(updateEventForm.getStart());
 			existingEvent.setEnd(updateEventForm.getEnd());
+			eventMapper.updateEvent(existingEvent);
+			return true;
 		}
-		eventMapper.updateEvent(existingEvent);
+		return false;
 	}
 	
 	// 일정 목록 조회하기
-	public List<Event> getEvents(Date startDate, Date endDate) {
-		return eventMapper.getEvents(convertDateToLocalDateTime(startDate), convertDateToLocalDateTime(endDate));
+	public List<Event> getEvents(int partyNo, Date startDate, Date endDate) {
+		return eventMapper.getEvents(partyNo, convertDateToLocalDateTime(startDate), convertDateToLocalDateTime(endDate));
 	}
 	
 	// 일정 상세정보 조회하기
-	public Event getEventDetail(int eventNo) {
-		return eventMapper.getEventDetailByNo(eventNo);
+	public Event getEventDetail(int id) {
+		return eventMapper.getEventDetailByNo(id);
 	}
 	
-	public Event getEventByNo(int eventNo) {
-		return eventMapper.getEventByNo(eventNo);
+	public Event getEventById(int id) {
+		return eventMapper.getEventByNo(id);
 	}
 	
 	private LocalDateTime convertDateToLocalDateTime(Date date) {

--- a/src/main/java/com/letsparty/vo/Event.java
+++ b/src/main/java/com/letsparty/vo/Event.java
@@ -2,6 +2,8 @@ package com.letsparty.vo;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -11,16 +13,17 @@ import lombok.ToString;
 @ToString
 public class Event {
 
-	private int no;
+	private int id;
+	@JsonIgnore
+	private Party party;
+	private User user;
 	private String title;
 	private String description;
 	private int status;
-	private int allDay;
+	private boolean allDay;
 	private LocalDateTime start;
 	private LocalDateTime end;
-	private Party party;
-//	private Place place;
-	private User user;
-//	private Post post;
+	private Post post;
+	private Place place;
 	
 }

--- a/src/main/java/com/letsparty/web/controller/EventController.java
+++ b/src/main/java/com/letsparty/web/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.letsparty.web.controller;
 
 
+import java.security.Principal;
 import java.util.Date;
 import java.util.List;
 
@@ -8,16 +9,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.letsparty.service.EventService;
 import com.letsparty.vo.Event;
-import com.letsparty.vo.User;
 import com.letsparty.web.form.RegisterEventForm;
 
 import lombok.extern.slf4j.Slf4j;
@@ -34,20 +34,17 @@ public class EventController {
 	
 	//@PreAuthorize("isAuthenticated()")
 	@PostMapping("/register")
-	@ResponseBody
-	public Event registerEvent(User user, RegisterEventForm registerEventform) {
-		user = new User();
-		user.setId("hong");
-		Event event = eventService.insertEvent(user, registerEventform);	
+	public Event registerEvent(RegisterEventForm registerEventform, Principal principal) {
+		Event event = eventService.insertEvent(registerEventform, principal.getName());	
 		log.info("일정 정보 -> {}", registerEventform);
 		
 		return event;
 	}
 	
-	@GetMapping("/{eventNo}")
-	public ResponseEntity<Event> getEventByNo(@PathVariable int eventNo) {
+	@GetMapping("/{id}")
+	public ResponseEntity<Event> getEventById(@PathVariable int id) {
 		// evetnNo를 사용하여 이벤트 조회
-		Event event = eventService.getEventByNo(eventNo);
+		Event event = eventService.getEventById(id);
 		
 		if (event != null) {
 			log.info("event: {}", event);
@@ -57,17 +54,20 @@ public class EventController {
 			return ResponseEntity.noContent().build();
 		}
 	}
-	/*
-	@PostMapping("/update/{eventNo}")
-	public ResponseEntity<String> updateEvent(@PathVariable int eventNo, @RequestBody RegisterEventForm updateEventForm) {
-		
-		return ResponseEntity.ok("success");
+	
+	@PostMapping("/update/{id}")
+	public ResponseEntity<String> updateEvent(@PathVariable int id, @ModelAttribute RegisterEventForm updateEventForm, Principal principal) {
+		if (eventService.updateEvent(id, updateEventForm, principal.getName())) {
+			return ResponseEntity.ok("success");
+		}
+		return ResponseEntity.badRequest().body("fail");
 	}
-	*/
+	
+	
 	@GetMapping("/events")
-	public List<Event> getEvents(@RequestParam("startDate") @DateTimeFormat(pattern="yyyy-MM-dd") Date startDate,
+	public List<Event> getEvents(int partyNo, @RequestParam("startDate") @DateTimeFormat(pattern="yyyy-MM-dd") Date startDate,
 			@RequestParam("endDate") @DateTimeFormat(pattern="yyyy-MM-dd") Date endDate) {
-		return eventService.getEvents(startDate, endDate);
+		return eventService.getEvents(partyNo, startDate, endDate);
 	}
 	
 	

--- a/src/main/java/com/letsparty/web/form/RegisterEventForm.java
+++ b/src/main/java/com/letsparty/web/form/RegisterEventForm.java
@@ -11,12 +11,12 @@ import lombok.Setter;
 @Setter
 public class RegisterEventForm {
 
+	private int partyNo;
 	private String title;
 	private String description;
+	private boolean allDay;
 	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
 	private LocalDateTime start;
 	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
 	private LocalDateTime end;
-	private int allDay;
-	private int partyNo;
 }

--- a/src/main/resources/mybatis/mapper/event.xml
+++ b/src/main/resources/mybatis/mapper/event.xml
@@ -39,7 +39,7 @@
 	</update>
 	
 	<select id="getEvents" parameterType="map" resultType="com.letsparty.vo.Event">
-		select
+		SELECT
 			event_no 			as id,
 			user_id				as "user.id",
 			event_title			as title,
@@ -50,12 +50,12 @@
 			event_end			as end,
 			post_id				as "post.id",
 			place_no			as "place.no"
-		from 
+		FROM
 			event
-		where
+		WHERE
 			party_no = #{partyNo} AND
-			event_end >= #{startDate} or
-			event_start &lt; #{endDate}
+			(event_end >= #{startDate} OR
+			event_start &lt; #{endDate})
 	</select>
 	
 	<select id="getEventByNo" parameterType="int" resultType="com.letsparty.vo.Event">

--- a/src/main/resources/mybatis/mapper/event.xml
+++ b/src/main/resources/mybatis/mapper/event.xml
@@ -2,55 +2,74 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.letsparty.mapper.EventMapper">
 	
-	<insert id="insertEvent" parameterType="com.letsparty.vo.Event" useGeneratedKeys="true" keyProperty="no">
-		
+	<insert id="insertEvent" parameterType="com.letsparty.vo.Event" useGeneratedKeys="true" keyProperty="id">
 		insert into event
-			(event_title, event_description, is_all_day, event_start, 
-			 event_end, event_status, user_id,
-			 place_no, post_id, party_no)
+			(party_no, user_id, event_title, event_description, event_status, is_all_day, event_start, event_end,
+			post_id, place_no)
 		values
-			(#{title}, #{description}, #{allDay}, 
-			#{start}, #{end},
-			#{status}, #{user.id}, null, null, 1)
+			(#{party.no}, #{user.id}, #{title}, #{description}, #{status}, #{allDay}, #{start}, #{end},
+			<choose>
+				<when test="post != null">
+					#{post.id}
+				</when>
+				<otherwise>
+					null
+				</otherwise>
+			</choose>,
+			<choose>
+				<when test="place != null">
+					#{place.no}
+				</when>
+				<otherwise>
+					null
+				</otherwise>
+			</choose>)
 	</insert>
 	
 	<update id="updateEvent" parameterType="com.letsparty.vo.Event">
-		update events
+		update event
 		set 
 			event_title = #{title},
 			event_description = #{description},
+			is_all_day = #{allDay},
 			event_start = #{start},
-			event_end = #{end},
-			is_all_day = #{allDay}
+			event_end = #{end}
 		where 
-			event_no = #{no}
+			event_no = #{id}
 	</update>
 	
 	<select id="getEvents" parameterType="map" resultType="com.letsparty.vo.Event">
 		select
-			event_no 			as no,
+			event_no 			as id,
+			user_id				as "user.id",
 			event_title			as title,
 			event_description 	as description,
+			event_status		as status,
 			is_all_day			as allDay,
 			event_start			as start,
 			event_end			as end,
-			event_status		as status
+			post_id				as "post.id",
+			place_no			as "place.no"
 		from 
 			event
 		where
+			party_no = #{partyNo} AND
 			event_end >= #{startDate} or
 			event_start &lt; #{endDate}
 	</select>
 	
 	<select id="getEventByNo" parameterType="int" resultType="com.letsparty.vo.Event">
 		select
-			event_no 			as no,
+			event_no 			as id,
+			user_id				as "user.id",
 			event_title			as title,
 			event_description 	as description,
+			event_status		as status,
 			is_all_day			as allDay,
 			event_start			as start,
 			event_end			as end,
-			event_status		as status
+			post_id				as "post_id",
+			place_no			as "place.no"
 		from 
 			event
 		where 
@@ -59,7 +78,7 @@
 	
 	<select id="getEventsByPartyNo" parameterType="int" resultType="com.letsparty.vo.Event">
 		SELECT
-			event_no 			as no,
+			event_no 			as id,
 			event_title			as title,
 			event_description 	as description,
 			is_all_day			as allDay,

--- a/src/main/resources/static/js/page/party/event.js
+++ b/src/main/resources/static/js/page/party/event.js
@@ -233,14 +233,14 @@ $(function() {
 				url: `/event/update/${eventId}`,
 				type: 'POST',
 				data: eventData,
-				success: function(response) {
+				success: function() {
 					let eventToUpdate = calendar.getEventById(eventId);
 					eventToUpdate.setProp('title', eventData.title);
 					let start = new Date(eventData.start);
 					start.setHours(start.getHours() - 9);
 					let end = new Date(eventData.end);
 					end.setHours(end.getHours() - 9);
-					eventToUpdate.setDates(start, end, {allDay: eventData.allDay});
+					eventToUpdate.setDates(start, end, { allDay: eventData.allDay });
 					calendar.getEventById(eventId).setExtendedProp('description', eventData.description);
 					$("#eventDetailModal").modal("hide");
 				},

--- a/src/main/resources/static/js/page/party/event.js
+++ b/src/main/resources/static/js/page/party/event.js
@@ -1,4 +1,6 @@
 $(function() {
+	const currentPath = window.location.pathname;
+	const partyNo = currentPath.split("/")[2];
 	/*	let clickedEvent;
 		 부트스트랩의 모달객체 생성하기
 		const eventModal = new bootstrap.Modal("#eventModal", {
@@ -53,9 +55,9 @@ $(function() {
 			// 원하는 지정 날짜에 일정등록하기
 			dateClick: function(info) {
 				// 일정을 클릭하기
-				var clickedDate = info.date;
+				let clickedDate = info.date;
 				// 날짜가 삽입된 모달 열기
-				openModalWithStartDate(clickedDate);
+				openModalWithClickedDate(clickedDate);
 				/*		        
 								$("#eventModal").modal("show");
 								var startDate = moment(info.event.start).format('YYYY-MM-DD');
@@ -72,6 +74,7 @@ $(function() {
 			},
 			// 일정을 수정하는 모달 열기
 			eventClick: function(info) {
+				clearEventField();
 				openEventDetailModal(info.event);
 
 			},
@@ -82,17 +85,21 @@ $(function() {
 
 					$.ajax({
 						url: '/event/events',
-						type: 'get',
-						data: { startDate: moment(info.start).format("YYYY-MM-DD"), endDate: moment(info.end).format("YYYY-MM-DD") },
+						type: 'GET',
+						data: { partyNo: partyNo, startDate: moment(info.start).format("YYYY-MM-DD"), endDate: moment(info.end).format("YYYY-MM-DD") },
 						success: function(data) {
-							var events = [];
+							let events = [];
 
 							data.forEach(function(eventData) {
-								var event = {
-									id: eventData.no,
+								let event = {
+									id: eventData.id,
 									title: eventData.title,
 									start: eventData.start,
-									end: eventData.end
+									end: eventData.end,
+									allDay: eventData.allDay,
+									extendedProps: {
+										description: eventData.description
+									}
 								};
 
 								events.push(event);
@@ -155,32 +162,9 @@ $(function() {
 		})
 
 		$("#save-event").click(function() {
-
-			let startDate = $(":input[name=startDate]").val();
-			console.log(`startDate: ${startDate}`);
-			let endDate = $(":input[name=endDate]").val();
-			let startTime = $(":input[name=startTime]").val();
-			console.log(`startTime: ${startTime}`);
-			let endTime = $(":input[name=endTime]").val();
-			let eventData = {
-				title: $(":input[name=title]").val(),
-				description: $(":input[name=description]").val(),
-			};
-			let allDay = $(":checkbox[name=allDay]:checked").val();
-			console.log("flag");
-			console.log(allDay);
-			if (allDay) {	// 체크되었다
-				eventData['allDay'] = 1;
-				eventData['start'] = new Date(`${startDate}T00:00:00`).toISOString();
-				endDate = new Date(`${endDate}T00:00:00`);
-				endDate.setDate(endDate.getDate() + 1);
-				eventData['end'] = endDate.toISOString();
-			} else {
-				eventData['allDay'] = 0;
-				eventData['start'] = new Date(`${startDate}T${startTime}:00`).toISOString();
-				eventData['end'] = new Date(`${endDate}T${endTime}:00`).toISOString();
-			}
-			addEvent(eventData);
+			let eventData = generateEventData();
+			eventData['partyNo'] = partyNo;
+			registerEvent(eventData);
 			$("#eventModal").modal("hide");
 		});
 		/*
@@ -208,104 +192,171 @@ $(function() {
 		*/
 		// 여기서 eventNo를 활용하여 해당 이벤트에 대한 정보를 가져와서 모달에 설정하는 등의 작업을 수행
 		$("#modify-event").click(function() {
+			let eventId = $("#eventDetailModal input[name='id']").val();
+			let eventData = generateEventDataForModification();
 
-			var eventNo = $("#eventDetailModal input[name='no']").val();
-			alert("일정번호: " + eventNo);
+			/*			let allDay = $(":checkbox[name=allDay]:checked").val();
+						if (allDay) {	// 체크되었다면
+							eventData['allDay'] = 1;
+						} else {
+							eventData['allDay'] = 0;
+							eventData['startTime'] = $(":input[name=startTime]").val();
+							eventData['endTime'] = $(":input[name=endTime]").val();
+						}
+			*/
 
-			var title = $("#eventDetailModal input[name='title']").val();
-			var description = $("#eventDetailModal input[name='description']").val();
-			var startDate = $("#eventDetailModal input[name='startDate']").val();
-			var startTime = $("#eventDetailModal input[name='startTime']").val();
-			var endDate = $("#eventDetailModal input[name='endDate']").val();
-			var endTime = $("#eventDetailModal input[name='endTime']").val();
-
-			let eventData = {
-				no: $("#eventDetailModal input[name='no']").val(),
-				title: $(":input[name=title]").val(),
-				description: $(":input[name=description]").val(),
-				startDate: $(":input[name=startDate]").val(),
-				startTime: $(":input[name=startTime]").val(),
-				endDate: $(":input[name=endDate]").val(),
-				endTime: $(":input[name=endTime]").val()
-			};
-
-			let allDay = $(":checkbox[name=allDay]:checked").val();
-			if (allDay) {	// 체크되었다면
-				eventData['allDay'] = 1;
-			} else {
-				eventData['allDay'] = 0;
-				eventData['startTime'] = $(":input[name=startTime]").val();
-				eventData['endTime'] = $(":input[name=endTime]").val();
-			}
-
-			// 캘린더에서 이벤트 찾기
-			var updateEvent = calendar.getEventById(eventNo);
-			if (updateEvent) {
-				// 이벤트 수정
-				updateEvent.setExtendedProp('title', title);
-				updateEvent.setExtendedProp('description', description);
-				updateEvent.setStart(startDate + "T" + startTime);
-				updateEvent.setEnd(endDate + "T" + endTime);
-			}
 
 			// 이벤트 업데이트 요청
+			/*			$.ajax({
+							url: `/event/${eventNo}`,
+							type: 'GET',
+							data: eventData,
+							dataType: 'json',
+							success: function(response) {
+			
+								// 수정된 이벤트 정보로 캘린더에서 찾아 업데이트
+								let updatedEvent = calendar.getEventById(eventNo);
+								if (updatedEvent) {
+									updatedEvent.setExtendedProp('title', title);
+									updatedEvent.setExtendedProp('description', description);
+									updatedEvent.setStart(startDate + "T" + startTime);
+									updatedEvent.setEnd(endDate + "T" + endTime);
+								}
+			
+								$("#eventDetailModal").modal("hide");
+							},
+							error: function(error) {
+								console.error("Error updating event:", error);
+							}
+						});*/
 			$.ajax({
-				url: `/event/${eventNo}`,
-				type: 'GET',
+				url: `/event/update/${eventId}`,
+				type: 'POST',
 				data: eventData,
-				dataType: 'json',
 				success: function(response) {
-
-					// 수정된 이벤트 정보로 캘린더에서 찾아 업데이트
-					var updatedEvent = calendar.getEventById(eventNo);
-					if (updatedEvent) {
-						updatedEvent.setExtendedProp('title', title);
-						updatedEvent.setExtendedProp('description', description);
-						updatedEvent.setStart(startDate + "T" + startTime);
-						updatedEvent.setEnd(endDate + "T" + endTime);
-					}
-
+					let eventToUpdate = calendar.getEventById(eventId);
+					eventToUpdate.setProp('title', eventData.title);
+					let start = new Date(eventData.start);
+					start.setHours(start.getHours() - 9);
+					let end = new Date(eventData.end);
+					end.setHours(end.getHours() - 9);
+					eventToUpdate.setDates(start, end, {allDay: eventData.allDay});
+					calendar.getEventById(eventId).setExtendedProp('description', eventData.description);
 					$("#eventDetailModal").modal("hide");
 				},
 				error: function(error) {
+					$("#eventDetailModal").modal("hide");
 					console.error("Error updating event:", error);
 				}
 			});
 
 		});
 
-		function addEvent(event) {
+		function registerEvent(eventData) {
 			$.ajax({
-				type: 'post',
 				url: '/event/register',
-				data: event,
+				type: 'POST',
+				data: eventData,
 				dataType: 'json'
 			})
-				.done(function(event) {
-					console.log(event)
-					calendar.addEvent(event);
+				.done(function(eventData) {
+					calendar.addEvent(eventData);
 				})
 		}
 	});
 
 	// 날짜가 적힌 모달 함수 열기
-	function openModalWithStartDate(StartDate, endDate) {
+	function openModalWithClickedDate(clickedDate) {
 		$("#eventModal").modal("show");
-		var formattedDate = moment(StartDate).format('YYYY-MM-DD');
-		$("#startDate").val(formattedDate);
-		var formattedDate = moment(endDate).format('YYYY-MM-DD');
-		$("#endDate").val(formattedDate);
+
+		let now = moment(); // 현재 시각을 얻습니다.
+		let formattedStartDate, formattedEndDate, startTime, endTime;
+
+		if (moment(clickedDate).isSame(now, 'day')) { // 클릭한 날짜가 오늘인 경우
+			formattedStartDate = now.add(1, 'hours').format('YYYY-MM-DD');
+			startTime = now.startOf('hour').format('HH:mm');
+			formattedEndDate = now.add(1, 'hours').format('YYYY-MM-DD');
+			endTime = now.startOf('hour').format('HH:mm');
+		} else { // 클릭한 날짜가 오늘이 아닌 경우
+			formattedStartDate = moment(clickedDate).format('YYYY-MM-DD');
+			formattedEndDate = moment(clickedDate).format('YYYY-MM-DD');
+			startTime = "08:00";
+			endTime = "09:00";
+		}
+
+		$("#startDate").val(formattedStartDate);
+		$("#startTime").val(startTime);
+		$("#endDate").val(formattedEndDate);
+		$("#endTime").val(endTime);
+
 	}
 
 	function openEventDetailModal(event) {
 		$("#eventDetailModal").modal("show");
-		$("#eventDetailModal input[name='no']").val(event.id);
+		$("#eventDetailModal input[name='id']").val(event.id);
 		$("#eventDetailModal input[name='title']").val(event.title);
 		$("#eventDetailModal input[name='description']").val(event.extendedProps.description);
-		$("#eventDetailModal input[name='startDate']").val(event.startStr);
-		$("#eventDetailModal input[name='startTime']").val(event.startStr);
-		$("#eventDetailModal input[name='endDate']").val(event.endStr);
-		$("#eventDetailModal input[name='endTime']").val(event.endStr);
+
+		// 체크박스의 상태를 설정합니다.
+		$("#eventDetailModal input[name='allDay']").prop('checked', event.allDay);
+
+		// 이벤트의 시작 및 종료 날짜 및 시간 설정
+		let start = moment(event.start);
+		let end = moment(event.end);
+		if (!event.allDay) {
+			$("#eventDetailModal input[name='startTime']").val(start.format('HH:mm'));
+			$("#eventDetailModal input[name='endTime']").val(end.format('HH:mm'));
+		} else {
+			end.subtract(1, 'days');
+		}
+		$("#eventDetailModal input[name='startDate']").val(start.format('YYYY-MM-DD'));
+		$("#eventDetailModal input[name='endDate']").val(end.format('YYYY-MM-DD'));
+	}
+
+	function generateEventData() {
+		let eventData = {
+			title: $(":input[name=title]").val(),
+			description: $(":input[name=description]").val(),
+		};
+		let startDate = $(":input[name=startDate]").val();
+		let endDate = $(":input[name=endDate]").val();
+		let startTime = $(":input[name=startTime]").val();
+		let endTime = $(":input[name=endTime]").val();
+		let allDay = $(":checkbox[name=allDay]").prop('checked');
+		eventData['allDay'] = allDay;
+		if (allDay) {
+			eventData['start'] = new Date(`${startDate}T00:00:00Z`).toISOString();
+			endDate = new Date(`${endDate}T00:00:00Z`);
+			endDate.setDate(endDate.getDate() + 1);
+			eventData['end'] = endDate.toISOString();
+		} else {
+			eventData['start'] = new Date(`${startDate}T${startTime}:00Z`).toISOString();
+			eventData['end'] = new Date(`${endDate}T${endTime}:00Z`).toISOString();
+		}
+		return eventData;
+	}
+
+	function generateEventDataForModification() {
+		let eventData = {
+			title: $("#eventDetailModal input[name='title']").val(),
+			description: $("#eventDetailModal input[name='description']").val(),
+		};
+		let startDate = $("#eventDetailModal input[name='startDate']").val();
+		let endDate = $("#eventDetailModal input[name='endDate']").val();
+		let startTime = $("#eventDetailModal input[name='startTime']").val();
+		let endTime = $("#eventDetailModal input[name='endTime']").val();
+		let allDay = $("#eventDetailModal input[name='allDay']").prop('checked');
+		eventData['allDay'] = allDay;
+		if (allDay) {
+			eventData['start'] = new Date(`${startDate}T00:00:00Z`).toISOString();
+			endDate = new Date(`${endDate}T00:00:00Z`);
+			endDate.setDate(endDate.getDate() + 1);
+			eventData['end'] = endDate.toISOString();
+		} else {
+			eventData['start'] = new Date(`${startDate}T${startTime}:00Z`).toISOString();
+			eventData['end'] = new Date(`${endDate}T${endTime}:00Z`).toISOString();
+		}
+		return eventData;
 	}
 	/*	var calendar = new FullCalendar.Calendar(calendarEl, {
 			initialView: 'dayGridMonth',

--- a/src/main/resources/templates/page/party/event.html
+++ b/src/main/resources/templates/page/party/event.html
@@ -3,7 +3,7 @@
    layout:decorate="~{layout/party-base}">
 <head>
 	<script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js'></script>
-	 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 	<script th:src="@{/js/page/party/ko.global.min.js}"></script>
 	<link rel="stylesheet" th:href="@{/css/page/party/event.css}" >
 </head>
@@ -55,7 +55,7 @@
 		                </div>
 		                <div class="modal-footer">
 		                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-		                    <button type="button" class="btn btn-primary" id="save-event" onclick="addSave">등록</button>
+		                    <button type="button" class="btn btn-primary" id="save-event">등록</button>
 		                </div>
 		            </div>
 		        </div>
@@ -74,7 +74,7 @@
 		          		<form th:value="10" id="modify-event-form">
 		          		-->
 			          		<div class="modal-body">
-			          			<input type="hidden" name="no">
+			          			<input type="hidden" name="id">
 			          			<div class="form-group">
 			                        <label for="taskId" class="col-form-label">일정 제목</label>
 			                        <input type="text" class="form-control" id="title" name="title">
@@ -89,7 +89,7 @@
 			                        <label for="taskId" class="col-form-label">종료 시간</label>
 			                        <input type="time" class="form-control" id="endTime" name="endTime">
 			                        <label for="taskId" class="col-form-label">하루 종일</label>
-			                        <input class="form-check-input" type="checkbox" name="allDay" role="switch" value="Y" ><br/>
+			                        <input class="form-check-input" type="checkbox" name="allDay" role="switch"><br/>
 			                    </div>
 								<div class="modal-footer">
 									<button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>

--- a/src/main/resources/templates/page/party/event.html
+++ b/src/main/resources/templates/page/party/event.html
@@ -1,175 +1,199 @@
 <html xmlns:th="http://www.thymeleaf.org"
-   xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-   layout:decorate="~{layout/party-base}">
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{layout/party-base}">
 <head>
 	<script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js'></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 	<script th:src="@{/js/page/party/ko.global.min.js}"></script>
-	<link rel="stylesheet" th:href="@{/css/page/party/event.css}" >
+	<link rel="stylesheet" th:href="@{/css/page/party/event.css}">
 </head>
-   <div layout:fragment="content-top" class="container">
-            <div id="calendar"></div>
-			<!-- 일정등록 Modal -->
-		    <div class="modal fade" id="eventModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel"
-		        aria-hidden="true">
-		        <div class="modal-dialog" role="document">
-		            <div class="modal-content">
-		                <div class="modal-header">
-		                    <h5 class="modal-title" id="exampleModalLabel">일정을 입력하세요.</h5>
-		                    <!--  
+<div layout:fragment="content-top" class="container">
+	<div id="calendar"></div>
+	<!-- 일정등록 Modal -->
+	<div class="modal fade" id="eventModal" tabindex="-1" role="dialog"
+		aria-labelledby="exampleModalLabel" aria-hidden="true">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" id="exampleModalLabel">일정을 입력하세요.</h5>
+					<!--  
 		                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
 		                        <span aria-hidden="true">&times;</span>
 		                    </button>
 		                    -->
-		                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-		                </div>
-		                <div class="modal-body">
-		                    <div class="form-group">
-		                        <label for="taskId" class="col-form-label">일정 제목</label>
-		                        <input type="text" class="form-control" id="title" name="title">
-		                        <label for="taskId" class="col-form-label">일정 내용</label>
-		                        <input type="text" class="form-control" id="description" name="description">
-		                        <label for="taskId" class="col-form-label">시작 날짜</label>
-		                        <input type="date" class="form-control" id="startDate" name="startDate">
-		                        <label for="taskId" class="col-form-label">종료 날짜</label>
-		                        <input type="date" class="form-control" id="endDate" name="endDate">
-		                        <label for="taskId" class="col-form-label">시작 시간</label>
-		                        <input type="time" class="form-control" id="startTime" name="startTime">
-		                        <label for="taskId" class="col-form-label">종료 시간</label>
-		                        <input type="time" class="form-control" id="endTime" name="endTime">
-		                        <label for="taskId" class="col-form-label">하루 종일</label>
-		                        <input class="form-check-input" type="checkbox" name="allDay" role="switch" value="Y" ><br/>
-		                        <!--  
+					<button type="button" class="btn-close" data-bs-dismiss="modal"
+						aria-label="Close"></button>
+				</div>
+				<div class="modal-body">
+					<div class="form-group">
+						<label for="taskId" class="col-form-label">일정 제목</label> <input
+							type="text" class="form-control" id="title" name="title">
+						<label for="taskId" class="col-form-label">일정 내용</label> <input
+							type="text" class="form-control" id="description"
+							name="description"> <label for="taskId"
+							class="col-form-label">시작 날짜</label> <input type="date"
+							class="form-control" id="startDate" name="startDate"> <label
+							for="taskId" class="col-form-label">종료 날짜</label> <input
+							type="date" class="form-control" id="endDate" name="endDate">
+						<label for="taskId" class="col-form-label">시작 시간</label> <input
+							type="time" class="form-control" id="startTime" name="startTime">
+						<label for="taskId" class="col-form-label">종료 시간</label> <input
+							type="time" class="form-control" id="endTime" name="endTime">
+						<label for="taskId" class="col-form-label">하루 종일</label> <input
+							class="form-check-input" type="checkbox" name="allDay"
+							role="switch" value="Y"><br />
+						<!--  
 		                        <label for="taskId" class="col-form-label">음력</label>
 		                        <input type="checkbox" name="option" value="lunar_calendar" ><br/>
 		                        -->
-		                        <label for="taskId" class="col-form-label">장소</label>
-		                        <input type="text" class="form-control" id="place" name="place">
-		                        
-		                        <label for="taskId" class="col-form-label">미리 알림</label>
-		                        <input type="text" class="form-control" id="noti" name="noti">
-		                        
-		                        <label for="taskId" class="col-form-label">게시글로 공유</label>
-		                         <input class="form-check-input" type="checkbox" name="sharePost" role="switch" value="Y" ><br/>
-		                    </div>
-		                </div>
-		                <div class="modal-footer">
-		                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-		                    <button type="button" class="btn btn-primary" id="save-event">등록</button>
-		                </div>
-		            </div>
-		        </div>
-		    </div>
-		    <!-- 일정 상세정보 모달 -->
-		    <div class="modal fade" id="eventDetailModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel"
-		        aria-hidden="true">
-		          <div class="modal-dialog" role="document">
-		            <div class="modal-content">
-		                <div class="modal-header">
-		                	<h5 class="modal-title" id="exampleModalLabel">일정을 수정하세요.</h5>
-		                	<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-		          		</div>
-		          		<!--  
+						<label for="taskId" class="col-form-label">장소</label> <input
+							type="text" class="form-control" id="place" name="place">
+
+						<label for="taskId" class="col-form-label">미리 알림</label> <input
+							type="text" class="form-control" id="noti" name="noti"> <label
+							for="taskId" class="col-form-label">게시글로 공유</label> <input
+							class="form-check-input" type="checkbox" name="sharePost"
+							role="switch" value="Y"><br />
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary"
+						data-bs-dismiss="modal">취소</button>
+					<button type="button" class="btn btn-primary" id="save-event">등록</button>
+				</div>
+			</div>
+		</div>
+	</div>
+	<!-- 일정 상세정보 모달 -->
+	<div class="modal fade" id="eventDetailModal" tabindex="-1"
+		role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" id="exampleModalLabel">일정을 수정하세요.</h5>
+					<button type="button" class="btn-close" data-bs-dismiss="modal"
+						aria-label="Close"></button>
+				</div>
+				<!--  
 		          		<form method="post" th:action="@{/party/{partyNo}/event(eventNo=${eventNo})" id="modify-event-form">
 		          		<form th:value="10" id="modify-event-form">
 		          		-->
-			          		<div class="modal-body">
-			          			<input type="hidden" name="id">
-			          			<div class="form-group">
-			                        <label for="taskId" class="col-form-label">일정 제목</label>
-			                        <input type="text" class="form-control" id="title" name="title">
-			                        <label for="taskId" class="col-form-label">일정 내용</label>
-			                        <input type="text" class="form-control" id="description" name="description">
-			                        <label for="taskId" class="col-form-label">시작 날짜</label>
-			                        <input type="date" class="form-control" id="startDate" name="startDate">
-			                        <label for="taskId" class="col-form-label">종료 날짜</label>
-			                        <input type="date" class="form-control" id="endDate" name="endDate">
-			                        <label for="taskId" class="col-form-label">시작 시간</label>
-			                        <input type="time" class="form-control" id="startTime" name="startTime">
-			                        <label for="taskId" class="col-form-label">종료 시간</label>
-			                        <input type="time" class="form-control" id="endTime" name="endTime">
-			                        <label for="taskId" class="col-form-label">하루 종일</label>
-			                        <input class="form-check-input" type="checkbox" name="allDay" role="switch"><br/>
-			                    </div>
-								<div class="modal-footer">
-									<button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
-									<button type="button" class="btn btn-primary btn-sm" id="modify-event">수정</button>
-								</div>
-							</div>
-	          			</div>
-	          		</div>
-	          	</div>
-        	<div id='external-events'>
-			    <p>
-			      <strong>원하는 날짜에 일정을 옮겨 등록하세요.</strong>
-			    </p>
-			
-			    <div class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
-			   		  <div class='fc-event-main'>국어</div>
-			    </div>
-			    <div class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
-			     	 <div class='fc-event-main'>수학</div>
-			    </div>
-			    <div class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
-			    	  <div class='fc-event-main'>영어</div>
-			    </div>
-			    <div class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
-			     	 <div class='fc-event-main'>체육</div>
-			    </div>
-			    <div class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
-			    	  <div class='fc-event-main'>음악</div>
-			    </div>
-				
-			    <p>
-			      <input type='checkbox' id='drop-remove' />
-			      <label for='drop-remove'>일정 등록 후 제거하기</label>
-			    </p>
-			    
-			    <div class="event-list">
-			    	<div class="border d-flex align-items-center" >
-                        <div class="col-1 me-2 ms-1 d-flex justify-content-center align-items-center">
-                            <div class="event-date">
-                                <h6 class="event-day">3</h6>
-                                <small>목요일</small>
-                            </div>
-                        </div>
-                        <div class="col-11">
-                            <div class="event-detail">
-                                <h6><strong>볼링 동호회</strong></h6>
-                                <small>오전 10:00</small>
-                            </div>
-                        </div>
-                   </div>
-			       <div class="border d-flex align-items-center" >
-                        <div class="col-1 me-2 ms-1 d-flex justify-content-center align-items-center">
-                            <div class="event-date">
-                                <h6 class="event-day">29</h6>
-                                <small>화요일</small>
-                            </div>
-                        </div>
-                        <div class="col-11">
-                            <div class="event-detail">
-                                <h6><strong>데이트</strong></h6>
-                                <small>오후 07:00</small>
-                            </div>
-                        </div>
-                   </div>
-			       <div class="border d-flex align-items-center" >
-                        <div class="col-1 me-2 ms-1 d-flex justify-content-center align-items-center">
-                            <div class="event-date">
-                                <h6 class="event-day">31</h6>
-                                <small>목요일</small>
-                            </div>
-                        </div>
-                        <div class="col-11">
-                            <div class="event-detail">
-                                <h6><strong>월말 정산</strong></h6>
-                                <small>오후 01:00</small>
-                            </div>
-                        </div>
-                   </div>
-			  </div>
+				<div class="modal-body">
+					<input type="hidden" name="id">
+					<div class="form-group">
+						<label for="taskId" class="col-form-label">일정 제목</label> <input
+							type="text" class="form-control" id="title" name="title">
+						<label for="taskId" class="col-form-label">일정 내용</label> <input
+							type="text" class="form-control" id="description"
+							name="description"> <label for="taskId"
+							class="col-form-label">시작 날짜</label> <input type="date"
+							class="form-control" id="startDate" name="startDate"> <label
+							for="taskId" class="col-form-label">종료 날짜</label> <input
+							type="date" class="form-control" id="endDate" name="endDate">
+						<label for="taskId" class="col-form-label">시작 시간</label> <input
+							type="time" class="form-control" id="startTime" name="startTime">
+						<label for="taskId" class="col-form-label">종료 시간</label> <input
+							type="time" class="form-control" id="endTime" name="endTime">
+						<label for="taskId" class="col-form-label">하루 종일</label> <input
+							class="form-check-input" type="checkbox" name="allDay"
+							role="switch"><br />
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-secondary btn-sm"
+							data-bs-dismiss="modal">닫기</button>
+						<button type="button" class="btn btn-primary btn-sm"
+							id="modify-event">수정</button>
+					</div>
+				</div>
 			</div>
-       	 </div>
-   <script layout:fragment="script" type="text/javascript" th:src="@{/js/page/party/event.js}"></script>
+		</div>
+	</div>
+	<div id='external-events'>
+		<p>
+			<strong>원하는 날짜에 일정을 옮겨 등록하세요.</strong>
+		</p>
+
+		<div
+			class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
+			<div class='fc-event-main'>국어</div>
+		</div>
+		<div
+			class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
+			<div class='fc-event-main'>수학</div>
+		</div>
+		<div
+			class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
+			<div class='fc-event-main'>영어</div>
+		</div>
+		<div
+			class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
+			<div class='fc-event-main'>체육</div>
+		</div>
+		<div
+			class='fc-event fc-h-event fc-daygrid-event fc-daygrid-block-event'>
+			<div class='fc-event-main'>음악</div>
+		</div>
+
+		<p>
+			<input type='checkbox' id='drop-remove' /> <label for='drop-remove'>일정
+				등록 후 제거하기</label>
+		</p>
+
+		<div class="event-list">
+			<div class="border d-flex align-items-center">
+				<div
+					class="col-1 me-2 ms-1 d-flex justify-content-center align-items-center">
+					<div class="event-date">
+						<h6 class="event-day">3</h6>
+						<small>목요일</small>
+					</div>
+				</div>
+				<div class="col-11">
+					<div class="event-detail">
+						<h6>
+							<strong>볼링 동호회</strong>
+						</h6>
+						<small>오전 10:00</small>
+					</div>
+				</div>
+			</div>
+			<div class="border d-flex align-items-center">
+				<div
+					class="col-1 me-2 ms-1 d-flex justify-content-center align-items-center">
+					<div class="event-date">
+						<h6 class="event-day">29</h6>
+						<small>화요일</small>
+					</div>
+				</div>
+				<div class="col-11">
+					<div class="event-detail">
+						<h6>
+							<strong>데이트</strong>
+						</h6>
+						<small>오후 07:00</small>
+					</div>
+				</div>
+			</div>
+			<div class="border d-flex align-items-center">
+				<div
+					class="col-1 me-2 ms-1 d-flex justify-content-center align-items-center">
+					<div class="event-date">
+						<h6 class="event-day">31</h6>
+						<small>목요일</small>
+					</div>
+				</div>
+				<div class="col-11">
+					<div class="event-detail">
+						<h6>
+							<strong>월말 정산</strong>
+						</h6>
+						<small>오후 01:00</small>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<script layout:fragment="script" type="text/javascript"
+	th:src="@{/js/page/party/event.js}"></script>
 </html>


### PR DESCRIPTION
## 구현사항
- allDay 자료형 int -> boolean
- 엔티티 중 외래키에 해당하는 자료형을 참조형으로 변경
- 등록기능에서 개발용 setId, partyNo 제거하고 실제를 반영

- event.js 일정수정 구현
  - 서버 제출 후 ok 응답 시 저장해둔 정보를 활용하여 화면에 반영
  - description 변경 extendedProps 반영
## 주의사항
- allDay 이벤트 end에 저장되는 날짜는 D+1임(다음날 0시)
- 일시가 시차만큼 늦어지는 문제를 막기 위하여 일정수정 시 서버응답 후 Date객체를 다시 만들어 반영
  - 원인: 현재 프로젝트에서는 로컬 시차를 서버데이터에 반영하지 않으며, 그대로 반영할 경우 시차가 적용됨