### PR TITLE
fix: 인터셉터의 preHandle를 필요한 상황에만 하도록 제한

### DIFF
--- a/src/main/java/com/letsparty/config/WebConfig.java
+++ b/src/main/java/com/letsparty/config/WebConfig.java
@@ -13,25 +13,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-   private final PartyInterceptor partyInterceptor;
-   private final NavbarInterceptor navbarInterceptor;
+	private final PartyInterceptor partyInterceptor;
+	private final NavbarInterceptor navbarInterceptor;
 
-   @Override
-   public void addInterceptors(InterceptorRegistry registry) {
-      registry.addInterceptor(navbarInterceptor)
-            .addPathPatterns("/", "/party/**", "/letsparty/**", "/my/**", "/party-create")
-            .excludePathPatterns("/css/**", "/js/**", "/images/**",
-            		"/party/{partyNo}",
-            		"/party/{partyNo}/read/{postNo}",
-            		"/party/{partyNo}/post/{postId}/comment",
-            		"/party/{partyNo}/withdraw/{upaNo}",
-            		"/my/profile/{profileNo}");
-      registry.addInterceptor(partyInterceptor)
-            .addPathPatterns("/party/{partyNo}/**")
-            .excludePathPatterns(
-            		"/party/{partyNo}",
-            		"/party/{partyNo}/read/{postNo}",
-            		"/party/{partyNo}/post/{postId}/comment",
-            		"/party/{partyNo}/withdraw/{upaNo}");
-   }
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(navbarInterceptor)
+				.addPathPatterns("/", "/party/**", "/letsparty/**", "/my/**", "/party-create")
+				.excludePathPatterns("/css/**", "/js/**", "/images/**",
+						"/party/{partyNo}",
+						"/party/{partyNo}/read/{postNo}",
+						"/party/{partyNo}/post/{postId}/comment",
+						"/party/{partyNo}/withdraw/{upaNo}",
+						"/my/profile/{profileNo}");
+		registry.addInterceptor(partyInterceptor)
+				.addPathPatterns("/party/{partyNo}/**")
+				.excludePathPatterns(
+						"/party/{partyNo}",
+						"/party/{partyNo}/read/{postNo}",
+						"/party/{partyNo}/post/{postId}/comment",
+						"/party/{partyNo}/withdraw/{upaNo}");
+	}
 }

--- a/src/main/java/com/letsparty/config/WebConfig.java
+++ b/src/main/java/com/letsparty/config/WebConfig.java
@@ -13,16 +13,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-	private final PartyInterceptor partyInterceptor;
-	private final NavbarInterceptor navbarInterceptor;
+   private final PartyInterceptor partyInterceptor;
+   private final NavbarInterceptor navbarInterceptor;
 
-	@Override
-	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(navbarInterceptor)
-				.addPathPatterns("/", "/party/**", "/letsparty/**", "/my/**", "/party-create")
-				.excludePathPatterns("/css/**", "/js/**", "/images/**", "/party/{partyNo}/setting/kick", "/{partyNo}/post/{postId}/comment", "/my/profile/{profileNo}", "/my/delete/{profileNo}");
-		registry.addInterceptor(partyInterceptor)
-				.addPathPatterns("/party/{partyNo}/**")
-				.excludePathPatterns("/party/{partyNo}/setting/kick");
-	}
+   @Override
+   public void addInterceptors(InterceptorRegistry registry) {
+      registry.addInterceptor(navbarInterceptor)
+            .addPathPatterns("/", "/party/**", "/letsparty/**", "/my/**", "/party-create")
+            .excludePathPatterns("/css/**", "/js/**", "/images/**",
+            		"/party/{partyNo}",
+            		"/party/{partyNo}/read/{postNo}",
+            		"/party/{partyNo}/post/{postId}/comment",
+            		"/party/{partyNo}/withdraw/{upaNo}",
+            		"/my/profile/{profileNo}");
+      registry.addInterceptor(partyInterceptor)
+            .addPathPatterns("/party/{partyNo}/**")
+            .excludePathPatterns(
+            		"/party/{partyNo}",
+            		"/party/{partyNo}/read/{postNo}",
+            		"/party/{partyNo}/post/{postId}/comment",
+            		"/party/{partyNo}/withdraw/{upaNo}");
+   }
 }

--- a/src/main/java/com/letsparty/web/controller/PartyController.java
+++ b/src/main/java/com/letsparty/web/controller/PartyController.java
@@ -1,7 +1,6 @@
 package com.letsparty.web.controller;
 
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -27,8 +26,6 @@ import com.letsparty.dto.BeginEndPostNo;
 import com.letsparty.dto.PartyReqDto;
 import com.letsparty.dto.PostAttachment;
 import com.letsparty.dto.SimplePostDto;
-import com.letsparty.mapper.PartyMapper;
-import com.letsparty.security.user.CustomUserDetails;
 import com.letsparty.security.user.LoginUser;
 import com.letsparty.service.CategoryService;
 import com.letsparty.service.MediaService;
@@ -36,10 +33,7 @@ import com.letsparty.service.PartyService;
 import com.letsparty.service.PostService;
 import com.letsparty.service.UserPartyApplicationService;
 import com.letsparty.service.UserProfileService;
-import com.letsparty.service.UserService;
-import com.letsparty.service.ValidationService;
 import com.letsparty.util.PartyDataUtils;
-import com.letsparty.vo.Media;
 import com.letsparty.vo.Party;
 import com.letsparty.vo.Post;
 import com.letsparty.vo.UserPartyApplication;
@@ -62,7 +56,6 @@ public class PartyController {
 	private final CategoryService categoryService;
 	private final UserProfileService userProfileService;
 	private final UserPartyApplicationService userPartyApplicationService;
-	private final UserService userService;
 	@Value("${s3.path.covers}")
 	private String coversPath;
 	@Value("${s3.path.profiles}")
@@ -194,7 +187,8 @@ public class PartyController {
 		
 		return "redirect:/party/{partyNo}/setting" ;
 	}
-	
+
+	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/{partyNo}/delete")
 	public String deleteParty(@AuthenticationPrincipal LoginUser loginUser, @PathVariable int partyNo, RedirectAttributes attributes) {
 		Party savedParty = partyService.getPartyByNo(partyNo);
@@ -312,7 +306,8 @@ public class PartyController {
 		model.addAttribute("upa", upa);
 		return "page/party/setting";
 	}
-	
+
+	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/{partyNo}/withdraw/{upaNo}")
 	public String withdraw(@PathVariable("partyNo") int partyNo, @PathVariable("upaNo") int upaNo) {
 		if (!userPartyApplicationService.withdraw(upaNo)) {

--- a/src/main/java/com/letsparty/web/interceptor/NavbarInterceptor.java
+++ b/src/main/java/com/letsparty/web/interceptor/NavbarInterceptor.java
@@ -31,6 +31,13 @@ public class NavbarInterceptor implements HandlerInterceptor {
 	@Override
 	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
 			@Nullable ModelAndView modelAndView) throws Exception {
+		if (!"GET".equals(request.getMethod())) {
+			return;
+		}
+		
+		String[] paths = request.getRequestURI().split("/");
+		modelAndView.addObject("paths", paths);
+		
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		boolean hasRegularRole = auth != null && !(auth instanceof AnonymousAuthenticationToken) && auth.getAuthorities().stream().noneMatch(authority -> authority.getAuthority().equals("ROLE_USER_PENDING"));
 		if (hasRegularRole) {

--- a/src/main/java/com/letsparty/web/interceptor/PartyInterceptor.java
+++ b/src/main/java/com/letsparty/web/interceptor/PartyInterceptor.java
@@ -25,7 +25,6 @@ import com.letsparty.service.ChatService;
 import com.letsparty.service.EventService;
 import com.letsparty.service.PartyService;
 import com.letsparty.service.UserPartyApplicationService;
-import com.letsparty.util.TimeConverter;
 import com.letsparty.vo.Event;
 import com.letsparty.vo.Party;
 import com.letsparty.vo.UserPartyApplication;
@@ -53,6 +52,9 @@ public class PartyInterceptor implements HandlerInterceptor {
 	@Override
 	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
 			ModelAndView modelAndView) throws Exception {
+		if (!"GET".equals(request.getMethod())) {
+			return;
+		}
 		
 		String uri = request.getRequestURI();
 		int partyNo = Integer.parseInt(uri.split("/")[2]);


### PR DESCRIPTION
## 구현사항
- WebConfig에 적용된 패턴 수정
- NavbarInterceptor 수정
- PartyInterceptor 수정
## 참고사항
- GetMapping 메서드만을 대상으로 수정
- GetMapping 중 redirect만 되는 것들도 제외