### PR TITLE
151 feat 채팅 접속 시 기존 대화내용 표시

### DIFF
--- a/src/main/java/com/letsparty/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/letsparty/mapper/ChatMessageMapper.java
@@ -1,14 +1,19 @@
 package com.letsparty.mapper;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import com.letsparty.vo.ChatMessage;
+import com.letsparty.vo.ChatUser;
 
 @Mapper
 public interface ChatMessageMapper {
 
 	void insertChatMessage(ChatMessage chatMessage);
+	
+    List<ChatMessage> getLatestMessagesForChatUser(ChatUser chatUser);
 	
 	void decreaseUnreadCntByRoomNoAndLastReadMessageNo(@Param("roomNo") long roomNo, @Param("lastReadMessageNo") long lastReadMessageNo);
 	void decreaseUnreadCntByRoomIdAndLastReadMessageNo(@Param("roomId") String roomId, @Param("lastReadMessageNo") long lastReadMessageNo);

--- a/src/main/java/com/letsparty/mapper/ChatUserMapper.java
+++ b/src/main/java/com/letsparty/mapper/ChatUserMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Param;
 
 import com.letsparty.dto.ChatUserResponse;
 import com.letsparty.dto.UserChatSummaryDto;
+import com.letsparty.vo.ChatMessage;
 import com.letsparty.vo.ChatUser;
 
 @Mapper
@@ -15,10 +16,12 @@ public interface ChatUserMapper {
 	boolean insertChatUser(ChatUser chatUser);
 	
 	ChatUser findById(ChatUser chatUser);
+	ChatUser findByRoomNoAndUserNo(ChatUser chatUser);
 	Long findLastReadMessageNoByRoomNoAndUserNo(ChatUser chatUser);
 	List<ChatUserResponse> findByRoomId(String roomId);
 	List<ChatUserResponse> findWithoutMeByRoomId(@Param("roomId") String roomId, @Param("myNo") int myNo);
 	ChatUserResponse findByRoomIdAndUserNo(@Param("roomId") String roomId, @Param("userNo") int userNo);
+	List<ChatUserResponse> findByRoomIdRegardlessOfLeft(String roomId);
 	List<UserChatSummaryDto> getUserChatSummary(int userNo);
 	
 	void updateLastReadMessageNoById(@Param("roomId") String roomId, @Param("userNo") int userNo);

--- a/src/main/java/com/letsparty/vo/ChatMessage.java
+++ b/src/main/java/com/letsparty/vo/ChatMessage.java
@@ -27,8 +27,9 @@ public class ChatMessage {
 	private String text;
 	
 	@Builder
-	public ChatMessage(long roomNo, int type, int userNo, LocalDateTime createdAt, Long unreadCnt, String text) {
+	public ChatMessage(long no, long roomNo, int type, int userNo, LocalDateTime createdAt, Long unreadCnt, String text) {
 		super();
+		this.no = no;
 		this.roomNo = roomNo;
 		this.type = type;
 		this.userNo = userNo;

--- a/src/main/java/com/letsparty/web/controller/ChatController.java
+++ b/src/main/java/com/letsparty/web/controller/ChatController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import com.letsparty.dto.ChatUserResponse;
 import com.letsparty.security.user.LoginUser;
 import com.letsparty.service.ChatService;
 

--- a/src/main/java/com/letsparty/web/controller/ChatRestController.java
+++ b/src/main/java/com/letsparty/web/controller/ChatRestController.java
@@ -1,12 +1,16 @@
 package com.letsparty.web.controller;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,16 +27,28 @@ import lombok.RequiredArgsConstructor;
 public class ChatRestController {
 
 	private final ChatService chatService;
-	
-	@GetMapping("/members/{roomId}")
-	public ResponseEntity<List<ChatUserResponse>> getUsersInRoom(@PathVariable final String roomId, @AuthenticationPrincipal LoginUser loginUser) {
-		List<ChatUserResponse> chatUsers = chatService.getUsersByRoomId(roomId, loginUser.getNo());
-		return ResponseEntity.ok(chatUsers);
+
+	@GetMapping("/init/{roomId}")
+	public ResponseEntity<Object[]> getUsersInRoom(@PathVariable final String roomId,
+			@AuthenticationPrincipal LoginUser loginUser) {
+		Object[] initInfo = chatService.getInitInfoByRoomId(roomId, loginUser.getNo());
+		if (initInfo == null) {
+			return ResponseEntity.badRequest().body(null);
+		}
+		return ResponseEntity.ok(initInfo);
 	}
-	
+
 	@GetMapping("/members/{roomId}/{userNo}")
-	public ResponseEntity<ChatUserResponse> findUserInPartyByRoomIdAndUserNo(@PathVariable final String roomId, @PathVariable final int userNo) {
+	public ResponseEntity<ChatUserResponse> findUserInPartyByRoomIdAndUserNo(@PathVariable final String roomId,
+			@PathVariable final int userNo) {
 		ChatUserResponse chatUser = chatService.getUserByRoomIdAndUserNo(roomId, userNo);
 		return ResponseEntity.ok(chatUser);
+	}
+
+	@PostMapping("/members/{roomId}")
+	public List<ChatUserResponse> findUserInPartyByRoomIdAndUserNo(@PathVariable final String roomId,
+			@RequestBody List<Integer> userNos) {
+		Set<Integer> userNosSet = new HashSet<>(userNos);
+		return chatService.getUsersByRoomIdRegardlessOfLeft(roomId, userNosSet);
 	}
 }

--- a/src/main/java/com/letsparty/web/websocket/interceptor/ChatChannelInterceptor.java
+++ b/src/main/java/com/letsparty/web/websocket/interceptor/ChatChannelInterceptor.java
@@ -1,29 +1,16 @@
 package com.letsparty.web.websocket.interceptor;
 
-import java.util.Map;
-
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
-import com.letsparty.mapper.ChatMessageMapper;
 import com.letsparty.mapper.ChatUserMapper;
-import com.letsparty.security.user.LoginUser;
-import com.letsparty.vo.ChatUser;
-import com.letsparty.web.websocket.dto.ChatMessageCon;
 import com.letsparty.web.websocket.service.SessionInfoMapper;
 import com.letsparty.web.websocket.service.SessionInfoMapper.SessionDetail;
 import com.letsparty.web.websocket.util.WebSocketUtils;

--- a/src/main/resources/mybatis/mapper/chat-message.xml
+++ b/src/main/resources/mybatis/mapper/chat-message.xml
@@ -9,6 +9,43 @@
 			(#{roomNo}, #{type}, #{userNo}, #{createdAt}, #{unreadCnt}, #{text})
 	</insert>
 	
+	<select id="getLatestMessagesForChatUser" parameterType="ChatUser" resultType="ChatMessage">
+		(
+			SELECT
+				message_no as no,
+				cm.room_no,
+				message_type as type,
+				user_no,
+				created_at,
+				unread_cnt,
+				message_text as text
+			FROM chat_message cm
+			JOIN chat_room cr ON cm.room_no = cr.room_no
+			WHERE cr.room_id = #{roomId} AND cm.message_no > #{lastReadMessageNo}
+			ORDER BY cm.message_no ASC
+		)
+		UNION ALL
+		(
+			SELECT *
+			FROM (
+				SELECT
+					message_no as no,
+					cm.room_no,
+					message_type as type,
+					user_no,
+					created_at,
+					unread_cnt,
+					message_text as text
+				FROM chat_message cm
+				JOIN chat_room cr ON cm.room_no = cr.room_no
+				WHERE cr.room_id = #{roomId} AND cm.message_no &lt;= #{lastReadMessageNo} AND cm.message_no >= #{joinMessageNo}
+				ORDER BY cm.message_no DESC
+				LIMIT 30
+			) AS t
+		)
+		ORDER BY no ASC;
+	</select>
+	
 	<update id="decreaseUnreadCntByRoomNoAndLastReadMessageNo">
 		UPDATE chat_message
 		SET

--- a/src/main/resources/mybatis/mapper/chat-user.xml
+++ b/src/main/resources/mybatis/mapper/chat-user.xml
@@ -19,6 +19,15 @@
 			AND user_no = #{userNo}
 	</select>
 
+	<select id="findByRoomNoAndUserNo" parameterType="ChatUser" resultType="ChatUser">
+		SELECT *
+		FROM
+			chat_user
+		WHERE
+			room_id = #{roomId}
+			AND user_no = #{userNo}
+	</select>
+
 	<select id="findLastReadMessageNoByRoomNoAndUserNo" parameterType="ChatUser" resultType="long">
 		SELECT
 			last_read_message_no
@@ -92,6 +101,22 @@
 			user_party_application upa
 		JOIN
 			user u ON u.user_no = #{userNo} AND upa.user_id = u.user_id
+		JOIN
+			chat_room cr ON cr.room_id = #{roomId} AND upa.party_no = cr.party_no
+		JOIN
+			user_profile up ON upa.profile_no = up.profile_no
+	</select>
+	
+	<select id="findByRoomIdRegardlessOfLeft" resultType="com.letsparty.dto.ChatUserResponse">
+		SELECT
+			u.user_no,
+			up.profile_nickname as nickname,
+			up.image_filename as filename,
+			up.is_url
+		FROM
+			user_party_application upa
+		JOIN
+			user u ON upa.user_id = u.user_id
 		JOIN
 			chat_room cr ON cr.room_id = #{roomId} AND upa.party_no = cr.party_no
 		JOIN


### PR DESCRIPTION
## 구현사항
- 날짜별 오름차순 삽입
- 초기 정보 추가
  - 기존: 방참가자
  - 추가: 안읽은로그 전부 및 과거로그 30개 중 본인 입장 이후, 마지막읽은번호
- 퇴장자가 있어 유저정보가 없는 경우 입장 초기 addUserInfoBatch 수행
- 로딩이 완료되면 마지막읽은번호로 부드럽게 이동
- [방 접속 시 안읽은수 감소 위치 변경
  - WsSubscribeEventListener -> ChatRestController.getUsersInRoom(), ChatService.getInitInfoByRoomId()
## 참고사항
- 파티 강퇴자의 채팅 로그에 관하여 유저정보를 조회할 수 없음. 아래 방법 중 택일 검토 필요.
  - promise를 이용하여 유저정보를 지연 갱신하는 방법
  - 퇴장한 유저기록을 지우지 않는 방법