### PR TITLE
fix: Fix by calculate unread count only from message type talk(0)

### DIFF
--- a/src/main/resources/mybatis/mapper/chat-user.xml
+++ b/src/main/resources/mybatis/mapper/chat-user.xml
@@ -170,7 +170,7 @@
 				ELSE p.party_name
 			END AS display_name,
 			p.party_filename,
-			SUM(CASE WHEN cm.message_no > cu.last_read_message_no THEN 1 ELSE 0 END) AS message_count,
+			SUM(CASE WHEN cm.message_no > cu.last_read_message_no AND cm.message_type = 0 THEN 1 ELSE 0 END) AS message_count,
 			lm.message_type,
 			lm.message_text,
 			up_latest.profile_nickname AS latest_message_nickname


### PR DESCRIPTION
## 구현사항
- navbar 채팅 모아보기의 안읽은수 계산에 message_type이 TALK(0)인 것만 세도록 수정
  - JOIN(1), EXIT(2) 때문에 입장해도 안읽은수가 사라지지 않는 문제 해결