### PR TITLE
style: 렛츠파티 로고에 a링크 추가 및 모바일 화면 nav 스타일 개선

### DIFF
--- a/src/main/resources/static/css/common/navbar.css
+++ b/src/main/resources/static/css/common/navbar.css
@@ -304,7 +304,7 @@ nav:nth-of-type(2) {
 		padding-left: 10%;
 		display: block;
 		height: 30px;
-		font-size: 0.9em;
+		font-size: 10px;
 		text-align: right;
 	}
 	.m-login .justify-content-end{
@@ -314,8 +314,8 @@ nav:nth-of-type(2) {
 		font-size: 20px;
 	}
 	.message-no-read {
-		top: 1px;
-	    left: 23px;
+		top: 2px;
+	    left: 16px;
 	    width: 15px;
 	    height: 15px;
 	}

--- a/src/main/resources/templates/common/navbar.html
+++ b/src/main/resources/templates/common/navbar.html
@@ -3,8 +3,7 @@
 		<div class="container m-nav fixed">
 			<div class="container m-lp">
 				<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-					<li class="nav-item"><a th:href="@{/letsparty}"
-						class="nav-link">렛츠 파티!!</a></li>
+					<li class="nav-item"></li>
 				</ul>
 			</div>
 			<div class="container m-search">

--- a/src/main/resources/templates/page/main/home.html
+++ b/src/main/resources/templates/page/main/home.html
@@ -8,7 +8,9 @@
 <!-- 고유 content -->
 <div layout:fragment="content-top" class="container">
         <h1 class="fs-3 home-logo">
-        	<img th:src="@{/images/party/logo1.png}">
+        	<a th:href="@{/letsparty}">
+	        	<img th:src="@{/images/party/logo1.png}">
+        	</a>
         </h1>
         <div class="container mt-3">
             <div class="row board-list"> 


### PR DESCRIPTION
<h1>구현사항</h1>

* 기존 nav에 "렛츠파티!!"를 삭제하고 하단 렛츠파티 로고 img에 a태그 추가
* 모바일 화면 로그인 로그아웃 부분 스타일 개선